### PR TITLE
Fix docstrings

### DIFF
--- a/src/ExpiringCaches.jl
+++ b/src/ExpiringCaches.jl
@@ -165,7 +165,7 @@ macro cacheable(timeout, func)
     return esc(quote
         const $cacheName = ExpiringCaches.Cache{Tuple{$(argTypes...)}, $returnType}($timeout)
         $internalFunction
-        function $funcName(args...)::$returnType
+        Base.@__doc__ function $funcName(args...)::$returnType
             return get!($cacheName, args) do
                 $internalFuncName(args...)
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,10 @@
 using Test, Dates, ExpiringCaches
 
+"""
+    foo(arg1::Int, arg2::String)
+
+Some docs to check that it doesn't break.
+"""
 ExpiringCaches.@cacheable Dates.Second(3) function foo(arg1::Int, arg2::String)::Float64
     sleep(2)
     return arg1 / length(arg2)


### PR DESCRIPTION
Thanks for the package, really nice.

This PR allows functions that use `cacheable` to have docstrings.

Closes #2