### PR TITLE
Call the f() function outside the lock section in the get! method to allow concurrency, even if the f() function causes heavy computation

### DIFF
--- a/src/ExpiringCaches.jl
+++ b/src/ExpiringCaches.jl
@@ -171,17 +171,19 @@ function Base.get!(cache::Cache{K, V}, key::K, default::V) where {K, V}
 end
 
 function Base.get!(f::Function, cache::Cache{K, V}, key::K) where {K, V}
-    lock(cache.lock) do
+    val = lock(cache.lock) do
         if haskey(cache.cache, key)
             x = cache.cache[key]
-            if expired(x, cache.strategy)
-                return setindex!(cache, f()::V, key)
-            else
+            if !expired(x, cache.strategy)
                 return x.value
             end
-        else
-            return setindex!(cache, f()::V, key)
         end
+        return nothing
+    end
+    val !== nothing && return val
+    computed = f()::V # heavy computation outside of lock
+    return lock(cache.lock) do
+        setindex!(cache, computed, key)
     end
 end
 


### PR DESCRIPTION
Hello!

I'm using ExpiringCaches.jl in my HTTP server to cache session states. When I tried to use this server in parallel mode (to process different user sessions in parallel), I found that the handler can't get session states and process them in parallel because the cache dictionary is locked until the previous process finishes working with it. So if the cacheable function producing session state causes heavy computation, we wait until it ends even to get another element of the cache.

I think I understand what you tried to prevent by this, but why can't we just call the f() function outside the lock section? Between get and set, making it lock, we could run parallel processes while calling f(). I see some problems with this, such as the ability to rewrite a cache element while f() is computing, so the cache state before and after calling f() could be different, but maybe this is not such a big problem for caching.

I've made this little PR with the example of the get! function.